### PR TITLE
Allow caller to specify custom SQL Server version.

### DIFF
--- a/src/SqlSharpener/MetaBuilder.cs
+++ b/src/SqlSharpener/MetaBuilder.cs
@@ -22,6 +22,7 @@ namespace SqlSharpener
         private bool _modelLoaded = false;
         private IEnumerable<Table> _tables;
         private IEnumerable<View> _views;
+        private dac.SqlServerVersion _sqlServerVersion = dac.SqlServerVersion.Sql100;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MetaBuilder"/> class.
@@ -29,6 +30,18 @@ namespace SqlSharpener
         /// <param name="sqlPaths">The paths to the *.sql files.</param>
         public MetaBuilder(params string[] sqlPaths)
         {
+            this.SqlPaths = new List<string>();
+            this.SqlPaths.AddRange(sqlPaths);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MetaBuilder"/> class.
+        /// </summary>
+        /// <param name="sqlServerVersion">The T-SQL syntax version.</param>
+        /// <param name="sqlPaths">The SQL paths.</param>
+        public MetaBuilder(dac.SqlServerVersion sqlServerVersion = dac.SqlServerVersion.Sql100, params string[] sqlPaths)
+        {
+            _sqlServerVersion = sqlServerVersion;
             this.SqlPaths = new List<string>();
             this.SqlPaths.AddRange(sqlPaths);
         }
@@ -119,7 +132,7 @@ namespace SqlSharpener
                 }
             }
 
-            var model = new dac.TSqlModel(dac.SqlServerVersion.Sql100, new dac.TSqlModelOptions());
+            var model = new dac.TSqlModel(_sqlServerVersion, new dac.TSqlModelOptions());
             foreach (var procFile in procFiles)
             {
                 model.AddObjects(File.ReadAllText(procFile));
@@ -135,7 +148,7 @@ namespace SqlSharpener
         /// <param name="sqlStatements">One or more sql statements to load, such as CREATE TABLE or CREATE PROCEDURE statements.</param>
         public void LoadModel(params string[] sqlStatements)
         {
-            var model = new dac.TSqlModel(dac.SqlServerVersion.Sql100, new dac.TSqlModelOptions());
+            var model = new dac.TSqlModel(_sqlServerVersion, new dac.TSqlModelOptions());
             foreach (var sqlStatement in sqlStatements)
             {
                 model.AddObjects(sqlStatement);


### PR DESCRIPTION
The MetaBuilder class uses a hard coded Sql100 (SQL Server 2008) version.  I ran into an issue where I was using newer syntax which caused error when parsing scripts.

This change allows the caller to specify their own version.  The default is still Sql100 which keeps this backward compatible.  For callers that want to override, I had to add an additional assembly reference in my T4 template.

    <#@ assembly name="$(SolutionDir)\packages\SqlSharpener.1.0.10\tools\SqlSharpener.dll" #>
    <#@ assembly name="$(SolutionDir)\packages\SqlSharpener.1.0.10\tools\Microsoft.SqlServer.Dac.Extensions.dll" #>
    
    <#
        var meta = new MetaBuilder(Microsoft.SqlServer.Dac.Model.SqlServerVersion.Sql120);

